### PR TITLE
fix(macos): enable MTKView layer opacity for transparent background

### DIFF
--- a/Sources/DotLottie/Public/DotLottieView.swift
+++ b/Sources/DotLottie/Public/DotLottieView.swift
@@ -32,6 +32,8 @@ public struct DotLottieView: ViewRepresentable, DotLottie {
     public func makeView(context: Context) -> MTKView {
 #if os(iOS)
         self.mtkView.isOpaque = false
+#elseif os(macOS)
+        self.mtkView.layer?.isOpaque = false
 #endif
         
         self.mtkView.framebufferOnly = false


### PR DESCRIPTION
The default background of the animation view renders as black, whereas on iOS it defaults to transparent.

I’ve set the default background of the macOS MTKView to transparent as well, to ensure consistent rendering results across both iOS and macOS.

| iOS | macOS | macOS(patched)
|:--:|:--:|:--:|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-24 at 22 41 45](https://github.com/user-attachments/assets/8d46a48d-8f00-4926-9034-bd77bacd938a) | ![TestLottieMac 2025-05-24 22 41 57](https://github.com/user-attachments/assets/674abeb7-40c7-46e7-aae4-54189b115953) | ![CleanShot 2025-05-24 at 22 52 35@2x](https://github.com/user-attachments/assets/e8f74657-eb5d-473b-903d-cc249f2f1709)




