### PR TITLE
Improve/Correct API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ class AnimationViewController: UIViewController {
 | `setMode(mode: Mode)` | Sets the animation play mode. |
 | `setSegments(segments: (Float, Float))` | Sets the start and end frame of the animation. |
 | `setBackgroundColor(color: CIImage)` | Sets the background color of the animation. |
-| `setFrameInterpolation(_ useFrameInterpolation: Bool)` | Use frame interpolation or not. |
-| `resize(width: Int, height: Int)` | Manually resize the animation. |
-| `setTheme(_ themeId: String)` | Load a theme. Only available with .lottie files. |
+| `setFrameInterpolation(_ useFrameInterpolation: Bool)` | Uses frame interpolation or not. |
+| `resize(width: Int, height: Int)` | Manually resizes the animation. |
+| `setTheme(_ themeId: String)` | Loads a theme. Only available with .lottie files. |
 | `setThemeData(_ themeData: String)` | Loads the passed theming data. |
-| `resetTheme()` | Remove the currently loaded theme. Only available with .lottie files. |
+| `resetTheme()` | Removes the currently loaded theme. Only available with .lottie files. |
 
 ### Event callbacks
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class AnimationViewController: UIViewController {
 
 The `DotLottieAnimation` instance emits the following events that can be listened to via a class implementing the `Observer` protocol:
 
-```
+```swift
 class YourDotLottieObserver: Observer {
     func onComplete() {
     }

--- a/README.md
+++ b/README.md
@@ -122,15 +122,14 @@ class AnimationViewController: UIViewController {
 | `setSpeed(speed: Int)` | Sets the playback speed with the given multiplier. |
 | `setLoop(loop: Bool)` | Configures whether the animation should loop continuously. |
 | `setFrame(frame: Float)` | Directly navigates the animation to a specified frame. |
-| `load(config: Config)` | Loads a new configuration or a new animation. |
-| `loadAnimation(animationId: String)` | Loads the animation by id. Animation id's are visible inside the manifest, recoverable via the manifest() method. |
+| `loadAnimationById(_ animationId: String)` | Loads the animation by id. Animation id's are visible inside the manifest, recoverable via the manifest() method. |
 | `setMode(mode: Mode)` | Sets the animation play mode. |
 | `setSegments(segments: (Float, Float))` | Sets the start and end frame of the animation. |
 | `setBackgroundColor(color: CIImage)` | Sets the background color of the animation. |
-| `setFrameInterpolation(useFrameInterpolation: Bool)` | Use frame interpolation or not. |
+| `setFrameInterpolation(_ useFrameInterpolation: Bool)` | Use frame interpolation or not. |
 | `resize(width: Int, height: Int)` | Manually resize the animation. |
-| `setTheme(themeId: String)` | Load a theme. Only available with .lottie files. |
-| `setThemeData(themeData: String)` | Loads the passed theming data. |
+| `setTheme(_ themeId: String)` | Load a theme. Only available with .lottie files. |
+| `setThemeData(_ themeData: String)` | Loads the passed theming data. |
 | `resetTheme()` | Remove the currently loaded theme. Only available with .lottie files. |
 
 ### Event callbacks


### PR DESCRIPTION
I've noticed, there are incorrect API signatures. Have fixed them for users to find correct exposed APIs.

![CleanShot 2025-05-25 at 00 06 36@2x](https://github.com/user-attachments/assets/fa3328e6-5f71-4bbb-ba5a-58af99d8e143)

Plus, added minor improvements for better readability
- unified verb-forms in API description
- specified `swift` langauge on markdown codeblock