### PR TITLE
Fixes App Store validation error by correcting invalid CFBundleShortVersionString format in DotLottiePlayer.xcframework

### DIFF
--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>13.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64_x86_64-maccatalyst/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64_x86_64-maccatalyst/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>13.1</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64_x86_64-simulator/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/ios-arm64_x86_64-simulator/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneSimulator</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>13.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/macos-arm64_x86_64/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/macos-arm64_x86_64/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>11.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/tvos-arm64-simulator/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/tvos-arm64-simulator/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>AppleTVSimulator</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>13.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/tvos-arm64/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/tvos-arm64/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>AppleTVOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>13.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/xros-arm64-simulator/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/xros-arm64-simulator/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>XRSimulator</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>1.0</string>
 </dict>

--- a/Sources/DotLottieCore/DotLottiePlayer.xcframework/xros-arm64/DotLottiePlayer.framework/Info.plist
+++ b/Sources/DotLottieCore/DotLottiePlayer.xcframework/xros-arm64/DotLottiePlayer.framework/Info.plist
@@ -13,13 +13,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>XROS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>version = 0.1.46</string>
+	<string>0.1.46</string>
 	<key>MinimumOSVersion</key>
 	<string>1.0</string>
 </dict>


### PR DESCRIPTION
  **Problem:**
  - Xcode Cloud builds were failing with validation error: "This bundle is invalid. The value for key CFBundleShortVersionString 'version = 0.1.46' in the Info.plist file at
  'Payload/{app_name}/Frameworks/DotLottiePlayer.framework' must be a period-separated list of at most three non-negative integers."

  **Solution:**
  - Updated all Info.plist files across all platform variants in DotLottiePlayer.xcframework
  - Changed CFBundleShortVersionString from `"version = 0.1.46"` to `"0.1.46"`
  - Changed CFBundleVersion from `"version = 0.1.46"` to `"0.1.46"`

  **Files Modified:**
  - 8 Info.plist files across all supported platforms (iOS, macOS, tvOS, visionOS - both device and simulator variants)

  **Impact:**
  - Resolves App Store validation failures
  - Ensures proper semantic versioning compliance
  - No functional changes to the framework behavior