### PR TITLE
Fix extra comma causing Xcode Cloud build failure

### DIFF
--- a/Sources/DotLottie/Public/DotLottieAnimation.swift
+++ b/Sources/DotLottie/Public/DotLottieAnimation.swift
@@ -132,7 +132,7 @@ public final class DotLottieAnimation: ObservableObject {
         fileName: String = "",
         webURL: String = "",
         config: AnimationConfig,
-        threads: Int? = nil,
+        threads: Int? = nil
     ) {
         if webURL != "" {
             self.init(webURL: webURL, config: config, threads: threads)


### PR DESCRIPTION
This PR removes an extra trailing comma in DotLottieAnimation.swift which prevents builds from succeeding on Xcode Cloud.
