### PR TITLE
Expose DotLottiePlayer as a separate library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,9 @@ let package = Package(
         .library(
             name: "DotLottie",
             targets: ["DotLottie", "DotLottiePlayer"]),
+        .library(
+            name: "DotLottiePlayer",
+            targets: ["DotLottiePlayer"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
## Problem

`DotLottiePlayer.xcframework` contains a **dynamic** library (`Mach-O 64-bit dynamically linked shared library`). When build tools like [Tuist](https://tuist.dev) resolve SPM packages into Xcode projects, they cannot embed the xcframework separately because it's only available as part of the combined `DotLottie` library product (which bundles both the `DotLottie` source target and the `DotLottiePlayer` binary target).

This causes a runtime crash on app launch:

```
Library not loaded: @rpath/DotLottiePlayer.framework/DotLottiePlayer
  Referenced from: .../MyApp.app/Frameworks/DesignSystem.framework/DesignSystem
```

The issue is tracked in:
- tuist/tuist#10296
- tuist/tuist#6638

## Solution

Expose `DotLottiePlayer` as its own library product in `Package.swift`:

```swift
.library(name: "DotLottiePlayer", targets: ["DotLottiePlayer"]),
```

This lets consumers depend on the binary xcframework directly, so the build system can detect it as a standalone dynamic xcframework and embed it in the app bundle.

## Impact

- **Non-breaking** — the existing `DotLottie` product is unchanged
- **Additive only** — adds a new product, no code changes
- Consumers who don't need separate access to `DotLottiePlayer` are unaffected