### PR TITLE
chore: bump CocoaPods podspec to 0.15.7

### DIFF
--- a/LottieFiles-dotLottie-iOS.podspec
+++ b/LottieFiles-dotLottie-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "LottieFiles-dotLottie-iOS"
-  spec.version      = "0.15.6"
+  spec.version      = "0.15.7"
   spec.summary      = "iOS player for .lottie and .json files."
 
   spec.description  = <<-DESC


### PR DESCRIPTION
## What

Bumps `LottieFiles-dotLottie-iOS.podspec` from `0.15.6` → `0.15.7`.

## Why

`v0.15.7` was tagged and released, but the in-repo podspec `version` was left at `0.15.6`, so the CocoaPods trunk lagged a release behind (latest published pod was `0.15.6`). The `v0.15.7` tag already contains the vendored `DotLottiePlayer.xcframework`, so no rebuild is needed.

`0.15.7` has now been published to the CocoaPods trunk (`pod trunk push`, validated for iOS + macOS). This change syncs `main` so the repo matches the released/published version and future releases start from the correct version.

## Notes

- Only the `version` line changes; `spec.source` resolves `:tag => "v#{spec.version}"` → `v0.15.7`.
- Verified installable: `pod 'LottieFiles-dotLottie-iOS', '~> 0.15.7'`.