### PR TITLE
fix(cocoapods): re-point DotLottiePlayer at WgpuNative.framework

### DIFF
--- a/cocoapods-release.sh
+++ b/cocoapods-release.sh
@@ -34,6 +34,30 @@ xcodebuild -create-xcframework \
     -output "$COCOAPODS_DIR/DotLottiePlayer.xcframework"
 
 # ---------------------------------------------------------------------------
+# Re-point DotLottiePlayer at the wrapped WgpuNative.framework.
+#
+# The prebuilt DotLottiePlayer slices link the raw wgpu dylib by its original
+# name — most via "@rpath/libwgpu_native.dylib", and the iOS arm64 *simulator*
+# slice via an absolute CI build path (.../libwgpu_native.dylib). For CocoaPods
+# we ship wgpu wrapped as WgpuNative.framework (below), so none of those
+# references resolve at runtime: the app crashes at launch with
+# "Library not loaded: .../libwgpu_native.dylib". Rewrite every libwgpu_native
+# reference, across all arch slices, to the framework's install name.
+# (SPM is unaffected — it ships the raw dylib, so the original name still matches.)
+# ---------------------------------------------------------------------------
+WGPU_INSTALL_NAME="@rpath/WgpuNative.framework/WgpuNative"
+while IFS= read -r dlp_bin; do
+    refs=$(for arch in $(lipo -archs "$dlp_bin"); do
+        otool -arch "$arch" -L "$dlp_bin"
+    done | awk '/libwgpu_native\.dylib/ { print $1 }' | sort -u)
+    for ref in $refs; do
+        [ "$ref" = "$WGPU_INSTALL_NAME" ] && continue
+        install_name_tool -change "$ref" "$WGPU_INSTALL_NAME" "$dlp_bin"
+    done
+done < <(find "$COCOAPODS_DIR/DotLottiePlayer.xcframework" \
+    -type f -name DotLottiePlayer -path '*/DotLottiePlayer.framework/*')
+
+# ---------------------------------------------------------------------------
 # WgpuNative — wrap each .dylib slice into a WgpuNative.framework.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Apps integrating `LottieFiles-dotLottie-iOS` via CocoaPods crash at launch on the iOS **arm64 simulator** (Apple Silicon):

```
dyld: Library not loaded: /Users/*/libwgpu_native.dylib
  Referenced from: .../DotLottiePlayer.framework/DotLottiePlayer
  Reason: tried: '.../libwgpu_native.dylib' (no such file)
```

## Root cause

`cocoapods-release.sh` wraps the raw `libwgpu_native.dylib` into a `WgpuNative.framework` (binary install name `@rpath/WgpuNative.framework/WgpuNative`), but `DotLottiePlayer.framework` is never updated to match. Its slices still link the dylib by its original name:

- most slices: `@rpath/libwgpu_native.dylib`
- the **ios-arm64 simulator** slice: an absolute CI build path, e.g. `/Users/runner/work/wgpu-native/wgpu-native/target/aarch64-apple-ios-sim/release/deps/libwgpu_native.dylib`

Neither resolves to the shipped `WgpuNative.framework`, so the dynamic loader fails at launch. `DotLottiePlayer` is loaded for the software renderer too, so this affects any consumer, not just WebGPU users. (SPM is unaffected — it ships the raw dylib under its original name, so `@rpath/libwgpu_native.dylib` still matches.)

## Fix

After repackaging `DotLottiePlayer.xcframework`, rewrite every `libwgpu_native.dylib` reference (across all arch slices, both the `@rpath` and absolute-path forms) to `@rpath/WgpuNative.framework/WgpuNative` with `install_name_tool -change`.

## Verification

Applying exactly this redirect to the embedded `DotLottiePlayer` binary of an already-built app on the arm64 simulator (then re-signing) makes the app launch cleanly — it previously crashed at launch. The change only touches the CocoaPods packaging script; SPM output is unchanged.
