### PR TITLE
docs: add animation-library tip and point docs at runtime docs

### DIFF
--- a/LottieFiles-dotLottie-iOS.podspec
+++ b/LottieFiles-dotLottie-iOS.podspec
@@ -9,7 +9,7 @@ Currently this package supports a mimimum iOS version of 13+ for iPhone and iPad
 This is a temporary pod name until we regain ownership of dotLottie-iOS. Use this pod for the latest updates from LottieFiles.
                    DESC
 
-  spec.homepage     = "https://github.com/LottieFiles/dotlottie-ios"
+  spec.homepage     = "https://docs.lottiefiles.com/en/runtimes/distributions/ios"
   spec.source       = { :git => "https://github.com/LottieFiles/dotlottie-ios.git", :tag => "v#{spec.version}" }
   spec.license      = { :type => 'MIT', :file => 'LICENSE' }
   spec.authors      = {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 <h1 align="center">dotLottie iOS</h1>
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
 ## Supported Devices
 
 - Currently this package supports a mimimum iOS version of 13.0+ for iPhone and iPad.
@@ -18,7 +21,7 @@
 
 ## Usage
 
-> Full documentation available [on the developer portal](https://developers.lottiefiles.com/docs/dotlottie-ios/).
+> Full documentation available [on the developer portal](https://docs.lottiefiles.com/en/runtimes/distributions/ios).
 
 1. Install the dependancy
 


### PR DESCRIPTION
- Adds the `[!TIP]` free-animations CTA to the README.
- Points the docs link and podspec `homepage` at `https://docs.lottiefiles.com/en/runtimes/distributions/ios` (was the old developer portal URL / GitHub).