### PR TITLE
fix: run deferred animation loading on the main actor

### DIFF
--- a/LottieFiles-dotLottie-iOS.podspec
+++ b/LottieFiles-dotLottie-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "LottieFiles-dotLottie-iOS"
-  spec.version      = "0.16.5"
+  spec.version      = "0.16.6"
   spec.summary      = "iOS player for .lottie and .json files."
 
   spec.description  = <<-DESC

--- a/Sources/DotLottie/Public/DotLottieAnimation.swift
+++ b/Sources/DotLottie/Public/DotLottieAnimation.swift
@@ -187,7 +187,7 @@ public final class DotLottieAnimation: ObservableObject {
         errorMessage: @escaping @Sendable (Error) -> String
     ) {
         self.init(config: config, threads: threads) { `self` in
-            Task {
+            Task { @MainActor in
                 do {
                     try await load(self)
                 } catch {


### PR DESCRIPTION
## Problem

`DotLottieAnimation`'s data/bundle initializers (`dotLottieData:`, `animationData:`, `fileName:`, `lottieData:`) run their load inside an unstructured `Task` with no actor isolation, so `loadDotlottieData` executes on a background thread. Meanwhile the main thread is already calling into the same raw player pointer (event-poll timer every 16ms, `tick` from the view's render timer, config setters), and `Player.loadDotlottieData` swaps/frees the software render buffer mid-flight.

The result is an intermittent `EXC_BAD_ACCESS` in `DotLottiePlayerBridge.loadDotlottieData` (garbage address, e.g. `0xbeaddece8888`). The `webURL:` initializer is unaffected because it already loads under `MainActor.run` — which is also why the crash only shows up with local/bundled sources (e.g. React Native release builds where assets resolve to `file://`).

## Fix

Bind the deferred load Task to the main actor, matching the `webURL:` path. All player FFI access is then serialized on the main thread.