### PR TITLE
OpenURL action enhancement (StateMachine)

### DIFF
--- a/Sources/DotLottie/Public/DotLottieAnimation.swift
+++ b/Sources/DotLottie/Public/DotLottieAnimation.swift
@@ -15,23 +15,6 @@ import CoreImage
 import UIKit
 #endif
 
-private class DotLottieAnimationInternalStateMachineObserver: StateMachineInternalObserver {
-    func onMessage(message: String) {
-        if message.hasPrefix("OpenUrl: ") {
-            var url = message.replacingOccurrences(of: "OpenUrl: ", with: "")
-            if let dotRange = url.range(of: " |") {
-              url.removeSubrange(dotRange.lowerBound..<url.endIndex)
-            }
-            #if os(iOS)
-            if let urlObject = URL(string: url),
-               UIApplication.shared.canOpenURL(urlObject) {
-                UIApplication.shared.open(urlObject, options: [:], completionHandler: nil)
-            }
-            #endif
-        }
-    }
-}
-
 // MARK: DotLottieAnimation
 public final class DotLottieAnimation: ObservableObject {
     @Published public var framerate: Int = 30
@@ -47,8 +30,6 @@ public final class DotLottieAnimation: ObservableObject {
     internal var config: Config
             
     internal var stateMachineListeners: [String] = []
-    
-    private var internalStateMachineObserver = DotLottieAnimationInternalStateMachineObserver()
 
     private var cachedStateMachineInputs: [String: String] = [:]
 
@@ -570,8 +551,6 @@ public final class DotLottieAnimation: ObservableObject {
 
     public func stateMachineStart(openUrlPolicy: OpenUrlPolicy = OpenUrlPolicy()) -> Bool {
         let sm = player.stateMachineStart(openUrlPolicy: openUrlPolicy)
-
-        let _ = player.stateMachineInternalSubscribe(observer: self.internalStateMachineObserver)
 
         self.stateMachineListeners = stateMachineFrameworkSetup().map { $0.lowercased() }
 

--- a/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
+++ b/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
@@ -8,6 +8,10 @@
 import Foundation
 import DotLottiePlayer
 
+#if os(iOS)
+import UIKit
+#endif
+
 // MARK: - Mode
 
 public enum Mode: UInt32 {
@@ -271,7 +275,7 @@ public struct Marker {
     }
 }
 
-// MARK: - OpenUrlPolicy
+// MARK: - OpenUrl
 
 public struct OpenUrlPolicy: Equatable, Hashable {
     public var requireUserInteraction: Bool
@@ -281,6 +285,27 @@ public struct OpenUrlPolicy: Equatable, Hashable {
         self.requireUserInteraction = requireUserInteraction
         self.whitelist = whitelist
     }
+}
+
+internal func parseOpenUrlMessage(_ message: String) -> URL? {
+    let prefix = "OpenUrl: "
+    guard message.hasPrefix(prefix) else { return nil }
+
+    var body = String(message.dropFirst(prefix.count))
+    if let separator = body.range(of: " |") {
+        body.removeSubrange(separator.lowerBound..<body.endIndex)
+    }
+
+    let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return URL(string: trimmed)
+}
+
+internal func openURLWithPlatformHandler(_ url: URL) {
+#if os(iOS)
+    guard UIApplication.shared.canOpenURL(url) else { return }
+    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+#endif
 }
 
 // MARK: - Events
@@ -1230,6 +1255,11 @@ public class DotLottiePlayer {
 
     private func handleStateMachineInternalEvent(_ event: dotlottieStateMachineInternalEvent) {
         let message = event.message.map { String(cString: $0) } ?? ""
+
+        if let url = parseOpenUrlMessage(message) {
+            openURLWithPlatformHandler(url)
+        }
+
         for observer in stateMachineInternalObservers {
             observer.onMessage(message: message)
         }

--- a/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
+++ b/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
@@ -8,8 +8,10 @@
 import Foundation
 import DotLottiePlayer
 
-#if os(iOS)
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
 #endif
 
 // MARK: - Mode
@@ -302,9 +304,14 @@ internal func parseOpenUrlMessage(_ message: String) -> URL? {
 }
 
 internal func openURLWithPlatformHandler(_ url: URL) {
-#if os(iOS)
+#if os(watchOS)
+    // watchOS has no such API available
+#elseif canImport(UIKit)
     guard UIApplication.shared.canOpenURL(url) else { return }
     UIApplication.shared.open(url, options: [:], completionHandler: nil)
+#elseif canImport(AppKit)
+    guard NSWorkspace.shared.urlForApplication(toOpen: url) != nil else { return }
+    NSWorkspace.shared.open(url)
 #endif
 }
 


### PR DESCRIPTION
## 1. `fix: handle state machine OpenUrl in WebGPUView`

test sample: [open-url.lottie](https://github.com/user-attachments/files/31145569/open-url.lottie.zip)

| Main | Patched |
|---|---|
| <img height="800" alt="Simulater lie tot Device" src="https://github.com/user-attachments/assets/12f3082f-1d67-478c-b154-62fd0d4df195" /> | <img height="800" alt="Ston Uo" src="https://github.com/user-attachments/assets/764167d9-8f47-4510-91f7-0d233313b8c3" /> |

In WGPU player, action was ignored.

## 2. `feat: open state machine URLs on macOS, tvOS and visionOS`

Another apple platforms did not handle openURL action, it was ignored. Expanding platform supports except watchOS.


https://github.com/user-attachments/assets/b592c4b6-1251-4ef7-8c72-bca898533514

