### PR TITLE
fix: expose state machine inputs to the WebGPU renderer

### DIFF
--- a/Sources/DotLottie/Public/DotLottieAnimation.swift
+++ b/Sources/DotLottie/Public/DotLottieAnimation.swift
@@ -31,8 +31,6 @@ public final class DotLottieAnimation: ObservableObject {
             
     internal var stateMachineListeners: [String] = []
 
-    private var cachedStateMachineInputs: [String: String] = [:]
-
     private var currFrame = 0
 
     private var loadingTask: Task<Void, Never>?
@@ -534,15 +532,11 @@ public final class DotLottieAnimation: ObservableObject {
     @discardableResult
     public func stateMachineLoad(id: String) -> Bool {
         config.stateMachineId = id
-        let ret = player.stateMachineLoad(id: id)
-        if ret { cachedStateMachineInputs = parseStateMachineInputs(from: getStateMachine(id)) }
-        return ret
+        return player.stateMachineLoad(id: id)
     }
-    
+
     public func stateMachineLoadData(_ data: String) -> Bool {
-        let ret = player.stateMachineLoadData(data)
-        if ret { cachedStateMachineInputs = parseStateMachineInputs(from: data) }
-        return ret
+        player.stateMachineLoadData(data)
     }
     
     public func stateMachineStop() -> Bool {
@@ -703,23 +697,9 @@ public final class DotLottieAnimation: ObservableObject {
     }
     
     public func stateMachineGetInputs() -> [String: String] {
-        return cachedStateMachineInputs
+        player.stateMachineGetInputs()
     }
 
-    private func parseStateMachineInputs(from json: String) -> [String: String] {
-        guard !json.isEmpty,
-              let data = json.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let inputs = obj["inputs"] as? [[String: Any]] else { return [:] }
-        var result: [String: String] = [:]
-        for input in inputs {
-            if let name = input["name"] as? String, let type_ = input["type"] as? String {
-                result[name] = type_
-            }
-        }
-        return result
-    }
-    
     public func stateMachineCurrentState() -> String {
         player.stateMachineCurrentState()
     }

--- a/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
+++ b/Sources/DotLottie/Public/DotLottiePlayerBridge.swift
@@ -407,6 +407,8 @@ public class DotLottiePlayer {
     private var stateMachineObservers: [StateMachineObserver] = []
     private var stateMachineInternalObservers: [StateMachineInternalObserver] = []
 
+    private var cachedStateMachineInputs: [String: String] = [:]
+
     private var eventPollTimer: Timer?
 
     public init(config: Config, threads: UInt32 = 0) {
@@ -1007,7 +1009,13 @@ public class DotLottiePlayer {
             stateMachinePtr = nil
         }
         stateMachinePtr = stateMachineId.withCString { dotlottie_state_machine_load(ptr, $0) }
-        return stateMachinePtr != nil
+        let ok = stateMachinePtr != nil
+        if ok {
+            cachedStateMachineInputs = Self.parseStateMachineInputs(
+                from: getStateMachine(stateMachineId: stateMachineId)
+            )
+        }
+        return ok
     }
 
     public func stateMachineLoadData(stateMachine: String) -> Bool {
@@ -1020,7 +1028,9 @@ public class DotLottiePlayer {
         stateMachinePtr = mutableBytes.withUnsafeMutableBufferPointer { buffer in
             buffer.baseAddress.flatMap { dotlottie_state_machine_load_data(ptr, $0) }
         }
-        return stateMachinePtr != nil
+        let ok = stateMachinePtr != nil
+        if ok { cachedStateMachineInputs = Self.parseStateMachineInputs(from: stateMachine) }
+        return ok
     }
 
     public func stateMachineStart(openUrlPolicy: OpenUrlPolicy = OpenUrlPolicy()) -> Bool {
@@ -1155,6 +1165,24 @@ public class DotLottiePlayer {
         return stateMachineId.withCString { idPtr in
             stringFromBufferAPI({ dotlottie_get_state_machine(ptr, idPtr, $0, $1) }) ?? ""
         }
+    }
+
+    public func stateMachineGetInputs() -> [String: String] {
+        cachedStateMachineInputs
+    }
+
+    private static func parseStateMachineInputs(from json: String) -> [String: String] {
+        guard !json.isEmpty,
+              let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let inputs = obj["inputs"] as? [[String: Any]] else { return [:] }
+        var result: [String: String] = [:]
+        for input in inputs {
+            if let name = input["name"] as? String, let type_ = input["type"] as? String {
+                result[name] = type_
+            }
+        }
+        return result
     }
 
     // MARK: - Observers

--- a/Sources/DotLottie/Public/Player.swift
+++ b/Sources/DotLottie/Public/Player.swift
@@ -319,9 +319,13 @@ class Player: ObservableObject {
     public func stateMachineFrameworkSetup() -> UInt16 {
         dotLottiePlayer.stateMachineFrameworkSetup()
     }
-    
+
     public func stateMachineCurrentState() -> String {
         dotLottiePlayer.stateMachineCurrentState()
+    }
+
+    public func stateMachineGetInputs() -> [String: String] {
+        dotLottiePlayer.stateMachineGetInputs()
     }
     
     public func duration() -> Float32 {


### PR DESCRIPTION
stateMachineGetInputs() API, it only defined in DotLottieAnimation, which DotLottieWebGPUView cannot go through. (missing one functionality)

Moved the shared logics down into DotLottiePlayerBridge, the layer both renderers can see. No behavior changes in DotLottieAnimation.

New API (DotLottieWebGPUView):
```swift
view.player.stateMachineGetInputs()
```